### PR TITLE
Update default mfa_serial when setting profile to assume

### DIFF
--- a/utils/shared_credentials_processor.go
+++ b/utils/shared_credentials_processor.go
@@ -111,4 +111,10 @@ func (processor AWSSharedCredentialsProcessor) SetSelectedAssumedProfileAsDefaul
 	} else {
 		defaultProfile.DeleteKey("region")
 	}
+
+	if selectedProfile.HasKey("mfa_serial") {
+		defaultProfile.Key("mfa_serial").SetValue(selectedProfile.Key("mfa_serial").Value())
+	} else {
+		defaultProfile.DeleteKey("mfa_serial")
+	}
 }


### PR DESCRIPTION
Currently when doing a `set` on a profile to assume, the `mfa_serial` key is not copied to the default profile even when it is present. 

This causes issues when the user does not have their `mfa_serial` manually set in the default profile, and potentially for other users who have different `mfa_serial` values between profiles to assume.